### PR TITLE
Bump clean-css version & add source map files support for minified css files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,35 +1,61 @@
-'use strict';
 
-const CleanCSS = require('clean-css');
+const CleanCSS = require( "clean-css" ) ;
 
-class CleanCSSMinifier {
-  constructor(config) {
-    this.options = config && config.plugins && config.plugins.cleancss || {};
+class CleanCSSMinifier 
+{
+  constructor( config ) 
+  {
+    this.options = config && config.plugins && config.plugins.cleancss || {} ;
   }
 
-  optimize(file) {
-    const data = file.data;
-    const path = file.path;
+  optimize( file ) 
+  {
+    const data = file.data ;
+    const path = file.path ;
 
-    try {
-      if (this.options.ignored && this.options.ignored.test(path)) {
+    try
+    {
+      if( this.options.ignored && this.options.ignored.test( path ) ) 
+      {
         // ignored file path: return non minified
         return Promise.resolve(data);
       }
-    } catch (e) {
+    } 
+    catch( e ) 
+    {
       return Promise.reject(`error checking ignored files to minify ${e}`);
     }
 
-    try {
-      const min = new CleanCSS(this.options).minify(data);
-      return Promise.resolve(min.styles || data);
-    } catch (error) {
+    try 
+    {
+      let prevMap = JSON.parse( file.map.toString() ) ; 
+      let min     = new CleanCSS( this.options ).minify( data , prevMap ) ; 
+      let currMap = JSON.parse( min.sourceMap.toString() ) ;
+      let newMap  = Object.assign( prevMap , currMap ) ;
+      let nFile   = 
+      {
+        data : min.styles ,
+        map  : newMap ,
+      };
+
+      let stdinIdx = nFile.map.sources.indexOf( "$stdin" ) ;
+
+      if( stdinIdx != -1 )
+      {
+        newMap.sourcesContent.splice( stdinIdx , 0 , "/* silence is golden */" ) ;
+      }
+
+      return Promise.resolve( nFile ) ;
+    } 
+    catch( error ) 
+    {
       return Promise.reject(`CSS minify failed on ${path}: ${error}`);
     }
   }
 }
 
-CleanCSSMinifier.prototype.brunchPlugin = true;
-CleanCSSMinifier.prototype.type = 'stylesheet';
+CleanCSSMinifier.prototype.brunchPlugin = true ;
+CleanCSSMinifier.prototype.extension = "css" ;
+CleanCSSMinifier.prototype.type = "stylesheet" ;
 
 module.exports = CleanCSSMinifier;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clean-css-brunch",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Adds CleanCSS support to brunch.",
   "author": "Paul Miller (http://paulmillr.com/)",
   "homepage": "https://github.com/brunch/clean-css-brunch",
@@ -13,7 +13,7 @@
     "test": "eslint index.js && mocha"
   },
   "dependencies": {
-    "clean-css": "~4.1"
+    "clean-css": "~4.2.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
1) Bump clean-css.

2) Add proper source map support for minified css files, without the patch, .map files are broken and are not useful anymore with devtools. This PR fixes that.